### PR TITLE
Fixed play button not returning to non play state

### DIFF
--- a/src/js/modules/text-to-speech.js
+++ b/src/js/modules/text-to-speech.js
@@ -1,5 +1,4 @@
 const synthesizer = globalThis.speechSynthesis;
-const utterance = new SpeechSynthesisUtterance();
 
 export function syntheticVoice() {
     const voices = synthesizer.getVoices();
@@ -20,12 +19,19 @@ export function syntheticVoice() {
  * @param {string} text - String of text to speak
  * @returns {void}
  */
-export function speak(text, isPaused = false) { 
+export function speak({text, endCallback, isPaused = false}) { 
     const voice = syntheticVoice();
+    const utterance = new SpeechSynthesisUtterance(text);
 
-    utterance.text = text;
     utterance.rate = 1;
     utterance.pitch = 1.2;
+    utterance.onerror = event => console.error(`
+        There was an error when reading ${event.name} at time ${event.elapsedTime} seconds, error: ${event.error} 
+    `);
+    
+    if (endCallback) {
+        utterance.onend = endCallback;
+    }
 
     if (voice) {
         utterance.voice = voice;

--- a/src/js/modules/userPost.js
+++ b/src/js/modules/userPost.js
@@ -14,9 +14,11 @@ export default {
     setup(props, { emit }) {
         const playingAudio = ref(false);
         const isPaused = ref(false);
-
+        
         const readText = text => {
-            speak(text, isPaused.value);
+            speak({text, isPaused: isPaused.value, endCallback: () => {
+                playingAudio.value = false;
+            }});
             emit("playerUsed", props.post.id);
 
             playingAudio.value = true;


### PR DESCRIPTION
Fixed play button displaying wrong state when a component's text is finished being read.

Fixed intermittent issue where wrong text would be read, or no text would be read. Ended up using separate instances of speech utterance class for each component, instead of a sharing one instance across all components.

Added error logging if speech utterance fails.